### PR TITLE
Automatic release version detection

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -101,7 +101,7 @@ The task exposes a few properties as part of its configuration.
 [options="header"]
 |===
 |Mandatory |Property | Description | Type | Default
-|Yes |releaseVersion | The version of the release |  String | empty
+|No |releaseVersion | The version of the release. If not set, version will be taken from gradle.properties ('version' property with stripped SNAPSHOT postfix) |  String | empty
 |No |allowSnapshotDependencies| Allow snapshot library dependencies | Boolean| false
 |No |baseCommit| You can optionally supply a base commit sha-1 hash to start the release from. The commit must be on the develop branch. | String| empty
 |===
@@ -110,6 +110,7 @@ The task exposes a few properties as part of its configuration.
 
 The tasks should be invoked via a command line.
 
+`gradlew releaseStart`
 `gradlew releaseStart -PreleaseVersion=1.0.0`
 
 === Release Finish Task
@@ -118,8 +119,8 @@ The tasks should be invoked via a command line.
 [options="header"]
 |===
 |Mandatory |Property | Description | Type | Default
-|Yes |releaseVersion | The version of the release |  String | empty
-|Yes |newVersion | The new version of the develop branch |  String | empty
+|No |releaseVersion | The version of the release. If not set, version will be taken from gradle.properties ('version' property with stripped SNAPSHOT postfix) |  String | empty
+|No |newVersion | The new version of the develop branch. If not set then releaseVersion with incremented patch part and SNAPSHOT postfix (http://semver.org/) |  String | empty
 |Yes |pushRelease | A flag indicating whether or not the finished release should be pushed to remote |  boolean | true
 |===
 
@@ -127,6 +128,8 @@ The tasks should be invoked via a command line.
 
 The tasks should be invoked via a command line.
 
+`gradlew releaseFinish
+`gradlew releaseFinish -PreleaseVersion=1.0.0
 `gradlew releaseFinish -PreleaseVersion=1.0.0 -PnewVersion=1.0.1-SNAPSHOT`
 `gradlew releaseFinish -PreleaseVersion=1.0.0 -PnewVersion=1.0.1-SNAPSHOT -PpushRelease=true`
 `gradlew releaseFinish -PreleaseVersion=1.0.0 -PnewVersion=1.0.1-SNAPSHOT -PpushRelease=false`

--- a/RELEASENOTES.adoc
+++ b/RELEASENOTES.adoc
@@ -36,3 +36,6 @@
 
 == Version 0.4.0
 * Issue #13: Implemented an option to disable pushing commits in releaseFinish task
+
+== Version 0.5.0
+* Added automatic version detection and incrementation for release tasks

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
     compile 'external.atlassian.jgitflow:jgit-flow-core:1.0-m5.1'
+    compile 'com.github.zafarkhaja:java-semver:0.9.0'
     testCompile("org.spockframework:spock-core:1.0-groovy-2.4") {
         exclude group: "org.codehaus.groovy"
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.4.0
+version=0.5.0

--- a/src/main/groovy/io/github/robwin/jgitflow/tasks/ReleaseFinishTask.groovy
+++ b/src/main/groovy/io/github/robwin/jgitflow/tasks/ReleaseFinishTask.groovy
@@ -20,6 +20,7 @@ package io.github.robwin.jgitflow.tasks
 import com.atlassian.jgitflow.core.JGitFlow
 import com.atlassian.jgitflow.core.ReleaseMergeResult
 import io.github.robwin.jgitflow.tasks.credentialsprovider.CredentialsProviderHelper
+import io.github.robwin.jgitflow.tasks.helper.ArtifactHelper
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.TaskAction
@@ -31,8 +32,8 @@ class ReleaseFinishTask extends DefaultTask {
 
     @TaskAction
     void finish(){
-        String releaseVersion = project.property('releaseVersion')
-        String newVersion = project.property('newVersion')
+        String releaseVersion = project.properties['releaseVersion']?:loadVersionFromGradleProperties()
+        String newVersion = project.properties['newVersion']?:ArtifactHelper.newSnapshotVersion(releaseVersion)
         boolean pushRelease = true
         if (project.properties.containsKey('pushRelease')) {
             pushRelease = Boolean.valueOf(project.property('pushRelease') as String)
@@ -68,5 +69,13 @@ class ReleaseFinishTask extends DefaultTask {
         }
 
         flow.git().close()
+    }
+
+
+    private String loadVersionFromGradleProperties() {
+        if(!project.hasProperty('version')) {
+            throw new GradleException('version or releaseVersion property have to be present')
+        }
+        ArtifactHelper.removeSnapshot(project.property('version') as String)
     }
 }

--- a/src/main/groovy/io/github/robwin/jgitflow/tasks/ReleaseStartTask.groovy
+++ b/src/main/groovy/io/github/robwin/jgitflow/tasks/ReleaseStartTask.groovy
@@ -33,7 +33,7 @@ class ReleaseStartTask extends DefaultTask {
     @TaskAction
     void start(){
 
-        String releaseVersion = project.property('releaseVersion')
+        String releaseVersion = project.properties['releaseVersion']?:loadVersionFromGradleProperties()
         CredentialsProviderHelper.setupCredentialProvider(project)
 
         validateReleaseVersion(releaseVersion)
@@ -67,6 +67,13 @@ class ReleaseStartTask extends DefaultTask {
         commitGradlePropertiesFile(flow.git(), "[JGitFlow Gradle Plugin] Updated gradle.properties for v" + releaseVersion + " release")
 
         flow.git().close()
+    }
+
+    private String loadVersionFromGradleProperties() {
+        if(!project.hasProperty('version')) {
+            throw new GradleException('version or releaseVersion property have to be present')
+        }
+        ArtifactHelper.removeSnapshot(project.property('version') as String)
     }
 
     private void validateReleaseVersion(String releaseVersion) {

--- a/src/main/groovy/io/github/robwin/jgitflow/tasks/helper/ArtifactHelper.java
+++ b/src/main/groovy/io/github/robwin/jgitflow/tasks/helper/ArtifactHelper.java
@@ -18,6 +18,8 @@
  */
 package io.github.robwin.jgitflow.tasks.helper;
 
+import com.github.zafarkhaja.semver.Version;
+
 import java.util.regex.Pattern;
 
 public class ArtifactHelper {
@@ -37,6 +39,17 @@ public class ArtifactHelper {
         }
 
         return false;
+    }
+
+    public static String removeSnapshot(String version) {
+        return Version.valueOf(version).getNormalVersion();
+    }
+
+    public static String newSnapshotVersion(String releaseVersion) {
+        return Version.valueOf(releaseVersion)
+                .incrementPatchVersion()
+                .setPreReleaseVersion(SNAPSHOT_VERSION)
+                .toString();
     }
 
 }

--- a/src/test/groovy/io/github/robwin/jgitflow/JGitflowTaskSpec.groovy
+++ b/src/test/groovy/io/github/robwin/jgitflow/JGitflowTaskSpec.groovy
@@ -22,6 +22,7 @@ import com.atlassian.jgitflow.core.JGitFlow
 import io.github.robwin.jgitflow.tasks.InitJGitflowTask
 import io.github.robwin.jgitflow.tasks.ReleaseFinishTask
 import io.github.robwin.jgitflow.tasks.ReleaseStartTask
+import io.github.robwin.jgitflow.tasks.helper.ArtifactHelper
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.lib.Ref
 import org.eclipse.jgit.revwalk.RevCommit
@@ -41,9 +42,15 @@ class JGitflowTaskSpec extends Specification{
     static final RELEASE_VERSION_1 = '0.0.1'
     static final RELEASE_VERSION_2 = '0.0.2'
     static final RELEASE_VERSION_3 = '0.0.3'
+    static final RELEASE_VERSION_4 = '0.0.4'
+    static final RELEASE_VERSION_5 = '0.0.5'
+    static final RELEASE_VERSION_6 = '0.2.0'
     static final NEW_VERSION_1 = '0.0.2-SNAPSHOT'
     static final NEW_VERSION_2 = '0.0.3-SNAPSHOT'
     static final NEW_VERSION_3 = '0.0.4-SNAPSHOT'
+    static final NEW_VERSION_4 = '0.0.5-SNAPSHOT'
+    static final NEW_VERSION_5 = '0.1.0-SNAPSHOT'
+    static final NEW_VERSION_6 = '0.2.1-SNAPSHOT'
 
     @Shared JGitFlow jGitFlow
 
@@ -318,5 +325,151 @@ class JGitflowTaskSpec extends Specification{
         remoteDevelopLog.get(0).fullMessage == "[JGitFlow Gradle Plugin] Updated ${Project.GRADLE_PROPERTIES} to version '${NEW_VERSION_3}'"
         remoteDevelopLog.get(1).fullMessage == "Merge branch '${jGitFlow.masterBranchName}' into ${jGitFlow.developBranchName}"
         remoteDevelopLog.get(2).fullMessage == "Merge branch '${jGitFlow.releaseBranchPrefix}${RELEASE_VERSION_3}'"
+    }
+
+    def "Test ReleaseFinishTask WithPushReleasesNotSet WithReleaseVersionNotSet WithNewVersionNotSet" () {
+        setup:
+
+        ReleaseStartTask releaseStartTask = project.tasks.findByName(JGitflowPlugin.RELEASE_START_TASK_NAME)
+        ReleaseFinishTask releaseFinishTask = project.tasks.findByName(JGitflowPlugin.RELEASE_FINISH_TASK_NAME)
+
+        loadGradleProperties()
+        String startVersion = gradleProperties.version
+
+
+        expect:
+        releaseStartTask != null
+        releaseFinishTask != null
+        ArtifactHelper.isSnapshot(startVersion)
+
+        when:
+        // we wrap the releaseStart with sleeping for one second, because otherwise the timestamps of the commits
+        // for the releaseStart and releaseFinish can be the same which can lead to a random order in the log.
+        // Since we are using the log to assert that our test passes, random ordering can cause our tests to fail.
+        // In practical usage, there will be time between a releaseStart and releaseFinish, so adding time between
+        // these calls is acceptable.
+        Thread.sleep(1000)
+        releaseStartTask.execute()
+        loadGradleProperties()
+        Thread.sleep(1000)
+
+        then:
+        notThrown(Throwable)
+        gradleProperties.version == RELEASE_VERSION_4
+
+        when:
+        releaseFinishTask.execute()
+        loadGradleProperties()
+        List<RevCommit> remoteMasterLog = log(remoteGit, jGitFlow.masterBranchName, 2)
+        //dumpLogs(remoteMasterLog, jGitFlow.masterBranchName)
+        List<RevCommit> remoteDevelopLog = log(remoteGit, jGitFlow.developBranchName, 3)
+        //dumpLogs(remoteDevelopLog, jGitFlow.developBranchName)
+
+        then:
+        notThrown(Throwable)
+        gradleProperties.version == NEW_VERSION_4
+        remoteMasterLog.get(0).fullMessage == "Merge branch '${jGitFlow.releaseBranchPrefix}${RELEASE_VERSION_4}'"
+        remoteMasterLog.get(1).fullMessage == "[JGitFlow Gradle Plugin] Updated ${Project.GRADLE_PROPERTIES} for v${RELEASE_VERSION_4} release"
+        remoteDevelopLog.get(0).fullMessage == "[JGitFlow Gradle Plugin] Updated ${Project.GRADLE_PROPERTIES} to version '${NEW_VERSION_4}'"
+        remoteDevelopLog.get(1).fullMessage == "Merge branch '${jGitFlow.masterBranchName}' into ${jGitFlow.developBranchName}"
+        remoteDevelopLog.get(2).fullMessage == "Merge branch '${jGitFlow.releaseBranchPrefix}${RELEASE_VERSION_4}'"
+    }
+
+    def "Test ReleaseFinishTask WithPushReleasesNotSet WithReleaseVersionNotSet" () {
+        setup:
+        project.ext.set('newVersion', NEW_VERSION_5)
+
+        ReleaseStartTask releaseStartTask = project.tasks.findByName(JGitflowPlugin.RELEASE_START_TASK_NAME)
+        ReleaseFinishTask releaseFinishTask = project.tasks.findByName(JGitflowPlugin.RELEASE_FINISH_TASK_NAME)
+
+        loadGradleProperties()
+        String startVersion = gradleProperties.version
+
+
+        expect:
+        releaseStartTask != null
+        releaseFinishTask != null
+        ArtifactHelper.isSnapshot(startVersion)
+
+        when:
+        // we wrap the releaseStart with sleeping for one second, because otherwise the timestamps of the commits
+        // for the releaseStart and releaseFinish can be the same which can lead to a random order in the log.
+        // Since we are using the log to assert that our test passes, random ordering can cause our tests to fail.
+        // In practical usage, there will be time between a releaseStart and releaseFinish, so adding time between
+        // these calls is acceptable.
+        Thread.sleep(1000)
+        releaseStartTask.execute()
+        loadGradleProperties()
+        Thread.sleep(1000)
+
+        then:
+        notThrown(Throwable)
+        gradleProperties.version == RELEASE_VERSION_5
+
+        when:
+        releaseFinishTask.execute()
+        loadGradleProperties()
+        List<RevCommit> remoteMasterLog = log(remoteGit, jGitFlow.masterBranchName, 2)
+        //dumpLogs(remoteMasterLog, jGitFlow.masterBranchName)
+        List<RevCommit> remoteDevelopLog = log(remoteGit, jGitFlow.developBranchName, 3)
+        //dumpLogs(remoteDevelopLog, jGitFlow.developBranchName)
+
+        then:
+        notThrown(Throwable)
+        gradleProperties.version == NEW_VERSION_5
+        remoteMasterLog.get(0).fullMessage == "Merge branch '${jGitFlow.releaseBranchPrefix}${RELEASE_VERSION_5}'"
+        remoteMasterLog.get(1).fullMessage == "[JGitFlow Gradle Plugin] Updated ${Project.GRADLE_PROPERTIES} for v${RELEASE_VERSION_5} release"
+        remoteDevelopLog.get(0).fullMessage == "[JGitFlow Gradle Plugin] Updated ${Project.GRADLE_PROPERTIES} to version '${NEW_VERSION_5}'"
+        remoteDevelopLog.get(1).fullMessage == "Merge branch '${jGitFlow.masterBranchName}' into ${jGitFlow.developBranchName}"
+        remoteDevelopLog.get(2).fullMessage == "Merge branch '${jGitFlow.releaseBranchPrefix}${RELEASE_VERSION_5}'"
+    }
+
+    def "Test ReleaseFinishTask WithPushReleasesNotSet WithNewVersionNotSet" () {
+        setup:
+        project.ext.set('releaseVersion', RELEASE_VERSION_6)
+
+        ReleaseStartTask releaseStartTask = project.tasks.findByName(JGitflowPlugin.RELEASE_START_TASK_NAME)
+        ReleaseFinishTask releaseFinishTask = project.tasks.findByName(JGitflowPlugin.RELEASE_FINISH_TASK_NAME)
+
+        loadGradleProperties()
+        String startVersion = gradleProperties.version
+
+
+        expect:
+        releaseStartTask != null
+        releaseFinishTask != null
+        ArtifactHelper.isSnapshot(startVersion)
+
+        when:
+        // we wrap the releaseStart with sleeping for one second, because otherwise the timestamps of the commits
+        // for the releaseStart and releaseFinish can be the same which can lead to a random order in the log.
+        // Since we are using the log to assert that our test passes, random ordering can cause our tests to fail.
+        // In practical usage, there will be time between a releaseStart and releaseFinish, so adding time between
+        // these calls is acceptable.
+        Thread.sleep(1000)
+        releaseStartTask.execute()
+        loadGradleProperties()
+        Thread.sleep(1000)
+
+        then:
+        notThrown(Throwable)
+        gradleProperties.version == RELEASE_VERSION_6
+
+        when:
+        releaseFinishTask.execute()
+        loadGradleProperties()
+        List<RevCommit> remoteMasterLog = log(remoteGit, jGitFlow.masterBranchName, 2)
+        //dumpLogs(remoteMasterLog, jGitFlow.masterBranchName)
+        List<RevCommit> remoteDevelopLog = log(remoteGit, jGitFlow.developBranchName, 3)
+        //dumpLogs(remoteDevelopLog, jGitFlow.developBranchName)
+
+        then:
+        notThrown(Throwable)
+        gradleProperties.version == NEW_VERSION_6
+        remoteMasterLog.get(0).fullMessage == "Merge branch '${jGitFlow.releaseBranchPrefix}${RELEASE_VERSION_6}'"
+        remoteMasterLog.get(1).fullMessage == "[JGitFlow Gradle Plugin] Updated ${Project.GRADLE_PROPERTIES} for v${RELEASE_VERSION_6} release"
+        remoteDevelopLog.get(0).fullMessage == "[JGitFlow Gradle Plugin] Updated ${Project.GRADLE_PROPERTIES} to version '${NEW_VERSION_6}'"
+        remoteDevelopLog.get(1).fullMessage == "Merge branch '${jGitFlow.masterBranchName}' into ${jGitFlow.developBranchName}"
+        remoteDevelopLog.get(2).fullMessage == "Merge branch '${jGitFlow.releaseBranchPrefix}${RELEASE_VERSION_6}'"
     }
 }


### PR DESCRIPTION
Changes for detecting automatically version from gradle.properties to release and incrementing new snapshot version.

'-PreleaseVersion' and '-PnewVersion' for releaseStart and releaseFinish jobs are optional in this change. 

If 'releaseVersion' is not set, version from gradle.properties without '-SNAPSHOT' is taken. 

If 'newVersion' is not set, next version is taken from releaseVersion with incremented patch version and '-SNAPSHOT' postfix. 

I also added appropriate tests for this functionality :)

I made those changes because maven jgitflow plugin already has such functionality and we would like to use it. Please, let me know what do you think of it.