### PR TITLE
issue-28 fixing misleading errors if version is missing or badly form…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -132,8 +132,8 @@ The tasks should be invoked via a command line.
 
 The tasks should be invoked via a command line.
 
-`gradlew releaseFinish
-`gradlew releaseFinish -PreleaseVersion=1.0.0
+`gradlew releaseFinish`
+`gradlew releaseFinish -PreleaseVersion=1.0.0`
 `gradlew releaseFinish -PreleaseVersion=1.0.0 -PnewVersion=1.0.1-SNAPSHOT`
 `gradlew releaseFinish -PreleaseVersion=1.0.0 -PnewVersion=1.0.1-SNAPSHOT -PpushRelease=true`
 `gradlew releaseFinish -PreleaseVersion=1.0.0 -PnewVersion=1.0.1-SNAPSHOT -PpushRelease=false`

--- a/src/main/groovy/io/github/robwin/jgitflow/tasks/ReleaseStartTask.groovy
+++ b/src/main/groovy/io/github/robwin/jgitflow/tasks/ReleaseStartTask.groovy
@@ -21,6 +21,7 @@ import com.atlassian.jgitflow.core.JGitFlow
 import io.github.robwin.jgitflow.tasks.credentialsprovider.CredentialsProviderHelper
 import io.github.robwin.jgitflow.tasks.helper.ArtifactHelper
 import org.gradle.api.GradleException
+import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.tasks.TaskAction
 
@@ -78,7 +79,12 @@ class ReleaseStartTask extends AbstractCommandTask {
         if(!project.hasProperty('version')) {
             throw new GradleException('version or releaseVersion property have to be present')
         }
-        ArtifactHelper.removeSnapshot(project.property('version') as String)
+        String version = project.property('version') as String
+        if (version == "unspecified") {
+            throw new GradleException("Cannot get version property from ${Project.GRADLE_PROPERTIES}")
+        }
+        
+        ArtifactHelper.removeSnapshot(version)
     }
 
     private void validateReleaseVersion(String releaseVersion) {

--- a/src/main/groovy/io/github/robwin/jgitflow/tasks/helper/GitHelper.groovy
+++ b/src/main/groovy/io/github/robwin/jgitflow/tasks/helper/GitHelper.groovy
@@ -18,6 +18,7 @@
  */
 package io.github.robwin.jgitflow.tasks.helper
 
+import org.apache.tools.ant.BuildException
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.LogCommand
 import org.eclipse.jgit.api.Status
@@ -100,7 +101,11 @@ class GitHelper {
         if (!propertiesFile.file) {
             propertiesFile.append("version=${version}")
         }else {
-            project.ant.replace(file: propertiesFile, token: "version=${currentVersion}", value: "version=${version}", failOnNoReplacements: true)
+            try {
+                project.ant.replace(file: propertiesFile, token: "version=${currentVersion}", value: "version=${version}", failOnNoReplacements: true)
+            } catch (BuildException e) {
+                throw new GradleException("Failed to update version in ${Project.GRADLE_PROPERTIES}.  Check the property exists and is formatted correctly.")
+            }
         }
     }
 


### PR DESCRIPTION
This give better error messages when the version property is either missing from gradle.properties or has spaces between the '='.