### PR TITLE
issue-30 Added property newVersionIncrement to control which part of …

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -122,7 +122,8 @@ The tasks should be invoked via a command line.
 |===
 |Mandatory |Property | Description | Type | Default
 |No |releaseVersion | The version of the release. If not set, version will be taken from gradle.properties ('version' property with stripped SNAPSHOT postfix) |  String | empty
-|No |newVersion | The new version of the develop branch. If not set then releaseVersion with incremented patch part and SNAPSHOT postfix (http://semver.org/) |  String | empty
+|No |newVersion | The new version of the develop branch. If not set then releaseVersion with incremented version and SNAPSHOT postfix (http://semver.org/) |  String | empty
+|No |newVersionIncrement | Controls which part of the version gets incremented when newVersion is set.  Can be one of PATCH, MINOR or MAJOR.   |  String | PATCH
 |Yes |pushRelease | A flag indicating whether or not the finished release should be pushed to remote |  boolean | true
 |No |scmMessagePrefix| You can optionally supply a SCM Prefix. | String| empty
 |No |scmMessageSuffix| You can optionally supply a SCM Suffix. | String| empty
@@ -132,8 +133,9 @@ The tasks should be invoked via a command line.
 
 The tasks should be invoked via a command line.
 
-`gradlew releaseFinish
-`gradlew releaseFinish -PreleaseVersion=1.0.0
+`gradlew releaseFinish`
+`gradlew releaseFinish -PnewVersionIncrement=PATCH`
+`gradlew releaseFinish -PreleaseVersion=1.0.0`
 `gradlew releaseFinish -PreleaseVersion=1.0.0 -PnewVersion=1.0.1-SNAPSHOT`
 `gradlew releaseFinish -PreleaseVersion=1.0.0 -PnewVersion=1.0.1-SNAPSHOT -PpushRelease=true`
 `gradlew releaseFinish -PreleaseVersion=1.0.0 -PnewVersion=1.0.1-SNAPSHOT -PpushRelease=false`

--- a/src/main/groovy/io/github/robwin/jgitflow/tasks/ReleaseFinishTask.groovy
+++ b/src/main/groovy/io/github/robwin/jgitflow/tasks/ReleaseFinishTask.groovy
@@ -29,10 +29,13 @@ import static io.github.robwin.jgitflow.tasks.helper.GitHelper.updateGradlePrope
 
 class ReleaseFinishTask extends AbstractCommandTask {
 
+    String DEFAULT_NEW_VERSION_INCREMENT = "PATCH"
+
     @TaskAction
     void finish(){
+        String newVersionIncrement = project.properties['newVersionIncrement'] ?: DEFAULT_NEW_VERSION_INCREMENT;
         String releaseVersion = project.properties['releaseVersion']?:loadVersionFromGradleProperties()
-        String newVersion = project.properties['newVersion']?:ArtifactHelper.newSnapshotVersion(releaseVersion)
+        String newVersion = project.properties['newVersion']?:ArtifactHelper.newSnapshotVersion(releaseVersion, newVersionIncrement)
         boolean pushRelease = true
         if (project.properties.containsKey('pushRelease')) {
             pushRelease = Boolean.valueOf(project.property('pushRelease') as String)

--- a/src/main/groovy/io/github/robwin/jgitflow/tasks/helper/ArtifactHelper.java
+++ b/src/main/groovy/io/github/robwin/jgitflow/tasks/helper/ArtifactHelper.java
@@ -19,6 +19,7 @@
 package io.github.robwin.jgitflow.tasks.helper;
 
 import com.github.zafarkhaja.semver.Version;
+import org.gradle.api.GradleException;
 
 import java.util.regex.Pattern;
 
@@ -45,11 +46,28 @@ public class ArtifactHelper {
         return Version.valueOf(version).getNormalVersion();
     }
 
-    public static String newSnapshotVersion(String releaseVersion) {
-        return Version.valueOf(releaseVersion)
-                .incrementPatchVersion()
-                .setPreReleaseVersion(SNAPSHOT_VERSION)
-                .toString();
+    public static String newSnapshotVersion(String releaseVersion, String newVersionIncrement) {
+
+        switch (newVersionIncrement.toUpperCase()) {
+            case "PATCH":
+                return Version.valueOf(releaseVersion)
+                        .incrementPatchVersion()
+                        .setPreReleaseVersion(SNAPSHOT_VERSION)
+                        .toString();
+            case "MINOR":
+                return Version.valueOf(releaseVersion)
+                        .incrementMinorVersion()
+                        .setPreReleaseVersion(SNAPSHOT_VERSION)
+                        .toString();
+            case "MAJOR":
+                return Version.valueOf(releaseVersion)
+                        .incrementMajorVersion()
+                        .setPreReleaseVersion(SNAPSHOT_VERSION)
+                        .toString();
+            default:
+                throw new GradleException("Invalid value '" + newVersionIncrement + "' for newVersionIncrement Property");
+
+        }
     }
 
 }

--- a/src/test/groovy/io/github/robwin/jgitflow/helper/ArtifactHelperSpec.groovy
+++ b/src/test/groovy/io/github/robwin/jgitflow/helper/ArtifactHelperSpec.groovy
@@ -1,0 +1,64 @@
+/*
+ *
+ *  Copyright 2016 Robert Winkler
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package io.github.robwin.jgitflow.helper
+
+import io.github.robwin.jgitflow.tasks.helper.ArtifactHelper
+import org.gradle.api.GradleException
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ArtifactHelperSpec extends Specification{
+
+    @Unroll
+    def "newSnapshotVersion increments returns #newVersion for paramters #oldVersion  #newVersionIncrement"() {
+
+        expect:
+        ArtifactHelper.newSnapshotVersion(oldVersion, newVersionIncrement) == newVersion
+
+        where:
+        oldVersion    | newVersionIncrement | newVersion
+
+        "1.0.0"       | "PATCH"             | "1.0.1-SNAPSHOT"
+        "2.1.4"       | "PATCH"             | "2.1.5-SNAPSHOT"
+        "3.2.1"       | "patch"             | "3.2.2-SNAPSHOT"
+        "3.12.13"     | "patch"             | "3.12.14-SNAPSHOT"
+
+        "1.2.3"       | "MINOR"             | "1.3.0-SNAPSHOT"
+        "2.4.9"       | "MINOR"             | "2.5.0-SNAPSHOT"
+        "3.11.0"      | "MINOR"             | "3.12.0-SNAPSHOT"
+
+        "1.2.3"       | "MAJOR"             | "2.0.0-SNAPSHOT"
+        "9.1.0"       | "MAJOR"             | "10.0.0-SNAPSHOT"
+    }
+
+    @Unroll
+    def "newSnapshotVersion throws exception when newVersionIncrement is #newVersionIncrement"() {
+
+        when:
+        ArtifactHelper.newSnapshotVersion("1.0.0", newVersionIncrement)
+
+        then:
+        thrown GradleException
+
+        where:
+        newVersionIncrement << ["", "test", "xyx"]
+    }
+
+
+}


### PR DESCRIPTION
…the version is incremented for releaseFinish task

Property newVersionIncrement specifies which part of the version gets incremented.

Takes values: PATCH (default), MINOR or MAJOR (also lowercase accepted).

Other values result in an error.
